### PR TITLE
fix: use DefaultRegionChain if AWS_REGION is not specified

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,13 +1,27 @@
 use std::env;
 use std::string::String;
+use aws_config::default_provider::region::DefaultRegionChain;
 use aws_types::region::Region;
 
 pub mod iam;
 pub mod sts;
 
+/// Retrieves the AWS region from the "AWS_REGION" environment variable if set,
+/// otherwise falls back to the default region determined by the DefaultRegionChain.
+async fn get_region() -> Region {
+    env::var("AWS_REGION")
+        .map(Region::new)
+        .unwrap_or({
+            DefaultRegionChain::builder()
+                .build()
+                .region()
+                .await
+                .expect("Failed to determine the AWS region.")
+        })
+}
+
 pub async fn load_config() -> aws_types::sdk_config::SdkConfig {
-    let aws_region = env::var("AWS_REGION").unwrap();
-    let region = Region::new(aws_region);
+    let region = get_region().await;
     aws_config::from_env().region(region).load().await
 }
 fn remove_whitespace(s: &mut String) {


### PR DESCRIPTION
### Description

Improve the way how AWS region is obtained by using the DefaultRegionChain if the `AWS_REGION` is not set


### Related issue
https://github.com/isotope-rs/isotope/issues/6